### PR TITLE
Make the module RedHat compatible

### DIFF
--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,0 +1,4 @@
+---
+tls_checker::package_provider: "puppet_gem"
+tls_checker::tls_checker_path: "/opt/puppetlabs/puppet/bin/tls-checker"
+tls_checker::group: "nobody"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,5 @@
+---
+tls_checker::group: "nogroup"
+tls_checker::package_provider: "gem"
+tls_checker::tls_checker_path: "/usr/local/bin/tls-checker"
+tls_checker::user: "nobody"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+hierarchy:
+  - name: 'Operating System Family'
+    path: '%{facts.os.family}.yaml'
+  - name: 'common'
+    path: 'common.yaml'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,7 @@
 # @summary Configure tls_checker
 #
+# @param package_provider Which package provider to use
+# @param tls_checker_path Path to tls-checker
 # @param logfile Logfile to store certificates status
 # @param ensure
 #
@@ -12,6 +14,11 @@
 # @param user User to check TLS status as
 # @param group Group to check TLS status as
 class tls_checker (
+  Optional[String]          $user,
+  Optional[String]          $group,
+  Enum['gem', 'puppet_gem'] $package_provider,
+  String                    $tls_checker_path,
+
   String $logfile = '/var/log/tls-checker.jsonl',
   String $ensure  = 'installed',
 
@@ -20,13 +27,10 @@ class tls_checker (
   Any $month    = undef,
   Any $monthday = undef,
   Any $weekday  = undef,
-
-  Optional[String] $user  = 'nobody',
-  Optional[String] $group = 'nogroup',
 ) {
   package { 'tls-checker':
     ensure   => $ensure,
-    provider => 'gem',
+    provider => $package_provider,
   }
 
   file { $logfile:
@@ -39,7 +43,7 @@ class tls_checker (
   $args = tls_checker::watched_endpoints().join(' ')
 
   cron { 'tls-checker':
-    command  => "/usr/local/bin/tls-checker -o ${logfile} ${args}",
+    command  => "${tls_checker_path} -o ${logfile} ${args}",
 
     hour     => $hour,
     minute   => $minute,


### PR DESCRIPTION
EL7 ships with a legacy version of Ruby nobody wants to use.  But since
Puppet ships with [a recent version of] Ruby, use it!