### PR TITLE
Do not default to nobody:nogroup for tls-checker

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,0 +1,4 @@
+---
+tls_checker::package_provider: "puppet_gem"
+tls_checker::tls_checker_path: "/opt/puppetlabs/puppet/bin/tls-checker"
+tls_checker::group: "nobody"

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,4 +1,3 @@
 ---
 tls_checker::package_provider: "puppet_gem"
 tls_checker::tls_checker_path: "/opt/puppetlabs/puppet/bin/tls-checker"
-tls_checker::group: "nobody"

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,4 +1,3 @@
 ---
 tls_checker::package_provider: "puppet_gem"
 tls_checker::tls_checker_path: "/opt/puppetlabs/puppet/bin/tls-checker"
-tls_checker::group: "nobody"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,3 @@
 ---
-tls_checker::group: "nogroup"
 tls_checker::package_provider: "gem"
 tls_checker::tls_checker_path: "/usr/local/bin/tls-checker"
-tls_checker::user: "nobody"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,8 +14,6 @@
 # @param user User to check TLS status as
 # @param group Group to check TLS status as
 class tls_checker (
-  Optional[String]          $user,
-  Optional[String]          $group,
   Enum['gem', 'puppet_gem'] $package_provider,
   String                    $tls_checker_path,
 
@@ -27,6 +25,9 @@ class tls_checker (
   Any $month    = undef,
   Any $monthday = undef,
   Any $weekday  = undef,
+
+  Optional[String] $user = undef,
+  Optional[String] $group = undef,
 ) {
   package { 'tls-checker':
     ensure   => $ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,13 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
@@ -26,6 +33,13 @@
       "operatingsystemrelease": [
         "12",
         "13"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -24,7 +24,6 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "11",
         "12",
         "13"
       ]


### PR DESCRIPTION
They are reserved for NFS purpose and running any service as these users
is a smell.  End users of the module are advised to manage a dedicated
user for the purpose of TLS checking.

This PR also include:
* #22 
* #23 
* #24 
* #25 